### PR TITLE
Correct logging example

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -14,6 +14,7 @@ Configuration
 
 Example configuration::
 
+    import dockerflow
     import logging.config
 
     cfg = {
@@ -41,7 +42,8 @@ Example configuration::
 
     logging.config.dictConfig(cfg)
 
-    logging.info('I am logging in mozlog format now! woo hoo!')
+    logger = logging.getLogger('myservicename')
+    logger.info('I am logging in mozlog format now! woo hoo!')
 
 
 In this example, we set up a logger for ``myservice`` (you'd replace that with


### PR DESCRIPTION
The example as shown does not work "as is" for 2 reasons:
 - ``dockerflow`` isn't imported (yes, not likely in production, but copy/paste working examples are nice)
 - a new logger needs to be created to utilize the new config